### PR TITLE
fix: :pencil2: remove use of `last-modified` in yml headers

### DIFF
--- a/onboarding/general-conduct/index.md
+++ b/onboarding/general-conduct/index.md
@@ -2,7 +2,8 @@
 title: "General Code of Conduct"
 description: |
   Material and resources for Conduct during events, meetings, and online spaces.
-date: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
   - name: Alisa Devedzic Kjærgaard 
     affiliations: 

--- a/onboarding/getting-started-phd/index.md
+++ b/onboarding/getting-started-phd/index.md
@@ -3,7 +3,8 @@ title: "Welcome and getting started as a PhD student"
 description: Material for onboarding new PhD students at SDCA.
 order: 2
 date: "2023-05-01"
-date-modified: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
     # Order alphabetical by last name
   - name: Julie Knudsen

--- a/onboarding/it-basics/index.md
+++ b/onboarding/it-basics/index.md
@@ -1,7 +1,8 @@
 ---
 title: "IT basics"
 description: A general introduction to common IT topics when starting out.
-date: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
     # Order alphabetical by last name
   - name: Daniel B. Ibsen

--- a/onboarding/meetings-and-events/index.md
+++ b/onboarding/meetings-and-events/index.md
@@ -1,7 +1,8 @@
 ---
 title: Meetings, courses, events, and social activities
 description: Details on various social activities and events at or connected with SDCA and finding more information about them.
-date: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
     # Order alphabetical by last name
   - name: Daniel B. Ibsen

--- a/onboarding/parking-at-auh/index.md
+++ b/onboarding/parking-at-auh/index.md
@@ -2,7 +2,8 @@
 title: "Parking at Aarhus University Hospital (AUH)"
 description: Information for parking at the hospital, as an AU or RM employee.
 date: "2023-04-14"
-date-modified: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
     # Order alphabetical by last name
   - name: Julie Knudsen

--- a/onboarding/practicalities/index.md
+++ b/onboarding/practicalities/index.md
@@ -1,7 +1,8 @@
 ---
 title: "General practicalities"
 description: Some basic setup and practicalities, like office supplies.
-date-modified: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
     # Order alphabetical by last name
   - name: Julie Knudsen

--- a/organization/people/index.md
+++ b/organization/people/index.md
@@ -2,7 +2,8 @@
 title: "People at SDCA"
 description: Profiles, titles, and contact information for people at SDCA.
 date: "2024-04-24"
-date-modified: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
   - name: Julie Knudsen
     affiliations:

--- a/organization/research-groups/index.md
+++ b/organization/research-groups/index.md
@@ -2,7 +2,8 @@
 title: "Research groups at SDCA"
 description: |
   The different research groups and topics at SDCA.
-date: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
     # Order alphabetical by last name
   - name: Daniel B. Ibsen

--- a/support/booking-rooms/index.md
+++ b/support/booking-rooms/index.md
@@ -1,6 +1,7 @@
 ---
 title: Booking meeting rooms at Forum
-date: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 description: |
   How to book rooms for meetings in the Forum building at AUH.
 author:

--- a/support/funding-application/index.md
+++ b/support/funding-application/index.md
@@ -3,7 +3,8 @@ title: "Funding applications"
 description: |
   Places to find sources of funding.
 date: "2023-06-26"
-date-modified: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
     # Order alphabetical by last name
   - name: Luke W. Johnston

--- a/support/legal-and-tto-templates/index.md
+++ b/support/legal-and-tto-templates/index.md
@@ -2,7 +2,8 @@
 title: "Common templates from TTO and Legal Office"
 description: Some templates relevant for Legal and Technology Transfer Office (TTO).
 date: "2023-04-14"
-date-modified: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
     # Order alphabetical by last name
   - name: Julie Knudsen

--- a/support/phd-defense/index.md
+++ b/support/phd-defense/index.md
@@ -2,7 +2,8 @@
 title: "How to organize a PhD defense"
 description: Organizing a PhD defense and the steps involved.
 date: "2023-05-10"
-date-modified: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 draft: true
 author:
     # Order alphabetical by last name

--- a/support/poster-printing/index.md
+++ b/support/poster-printing/index.md
@@ -2,7 +2,8 @@
 title: "Printing posters for events"
 description: How to print a poster for an event like a conference or meeting.
 date: "2023-06-26"
-date-modified: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
     # Order alphabetical by last name
   - name: Luke W. Johnston

--- a/support/reimbursements/index.md
+++ b/support/reimbursements/index.md
@@ -2,7 +2,8 @@
 title: "Reimbursements through AUH"
 description: "Procedures for reimbursement of transport and other expenses from AUH funds."
 date: "2024-04-24"
-date-modified: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
     # Order alphabetical by last name
   - name: Julie Knudsen

--- a/support/requesting-data/index.md
+++ b/support/requesting-data/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Requesting access to various data sources"
-date: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 description: |
   Material for applying to various data sources, including the Danish registers.
 author:

--- a/support/running-meetings/index.md
+++ b/support/running-meetings/index.md
@@ -1,6 +1,7 @@
 ---
 title: "How to run an effective meeting"
-date: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 description: |
   Guidelines and suggestions for running effective meetings.
 author:

--- a/support/travel-booking/index.md
+++ b/support/travel-booking/index.md
@@ -2,7 +2,8 @@
 title: "Booking for travel"
 description: Steps to take to book for work-related travel.
 date: "2023-04-14"
-date-modified: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
     # Order alphabetical by last name
   - name: Julie Knudsen

--- a/support/verdensrummet/index.md
+++ b/support/verdensrummet/index.md
@@ -2,7 +2,8 @@
 title: "Stream a local meeting from Verdensrummet"
 description: Whenever running a meeting or event in Verdensrummet, you can stream it if you want by using this guide.
 date: "2023-05-01"
-date-modified: last-modified
+# Update this whenever a change has been made.
+# date-modified: ""
 author:
     # Order alphabetical by last name
   - name: Julie Knudsen


### PR DESCRIPTION
# Description

I've replaced all `date: last-modified` and `date-modified: last-modified` with `# date-modified: "".` since `last-modified` doesn't do as we expected it to (as 
@lwjohnst86 mentioned in #128 ); the date of `last-modified` will be the date the document was last rebuilt and not the date the text (or styling or the like) was changed in the document.