### PR TITLE
style: 🎨 prettify landing page buttons

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -8,11 +8,10 @@ about:
     image-width: 35em
     image-shape: rounded
     image-alt: "Design image of a microscope pointed at a sample."
-    links:
-      - text: "Onboarding"
-        href: "https://steno-aarhus.github.io/research/onboarding.html"
-      - text: "Support"
-        href: "https://steno-aarhus.github.io/research/support.html"
-      - text: "Organization"
-        href: "https://steno-aarhus.github.io/research/organization.html"
 ---
+
+::: {.text-center}
+[Onboarding](https://steno-aarhus.github.io/research/onboarding.html){.btn .btn-primary role="button"}
+[Support](https://steno-aarhus.github.io/research/support.html){.btn .btn-primary role="button"}
+[Organization](https://steno-aarhus.github.io/research/organization.html){.btn .btn-primary role="button"}
+:::

--- a/index.qmd
+++ b/index.qmd
@@ -2,7 +2,6 @@
 title: "SDCA Research: Common Docs and Support"
 subtitle: "Resources and support for conducting research at Steno Diabetes Center Aarhus."
 image: images/home-banner.jpg
-title-block-banner: false
 about:
     template: jolla
     image-width: 35em


### PR DESCRIPTION
So they now look like: 

<img width="547" height="386" alt="image" src="https://github.com/user-attachments/assets/4fc5aac2-6361-44d9-ba04-8ba3504fc845" />

Instead of: 

<img width="933" height="711" alt="image" src="https://github.com/user-attachments/assets/e6c71ec5-ee34-4769-8430-d3ca4c474894" />
