### PR TITLE
fix: :bug: add missing affiliations metadata to yml header

### DIFF
--- a/support/external-speakers/index.md
+++ b/support/external-speakers/index.md
@@ -9,6 +9,8 @@ author:
   - name: Julie Knudsen
     affiliations:
       - ref: sdca
+metadata-files: 
+  - ../../_affiliations.yml
 ---
 
 ## Payment of external parties for presentations, seminars, workshops etc.


### PR DESCRIPTION
The website build currently [fails](https://github.com/steno-aarhus/research/actions/runs/31174453668/job/92853251446) bc of this.